### PR TITLE
Improve Proto Documentation Build and HTML Comment Rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,30 @@ help: ## Print usage info about help targets
 makefile_chapters: ## Shows all sections of Makefile
 	@echo `cat Makefile| grep "########################################################" -A 1 | grep -v "########################################################"`
 
+build_docs: ## Build documentation locally using the same Docker image as CI/CD
+	@echo "Building documentation using ondewo-protoc-gen-doc-action..."
+	@if [ ! -d ".tmp-protoc-gen-doc-action" ]; then \
+		echo "Cloning ondewo-protoc-gen-doc-action..."; \
+		git clone --depth 1 https://github.com/ondewo/ondewo-protoc-gen-doc-action.git .tmp-protoc-gen-doc-action; \
+	fi
+	@echo "Building Docker image with ONDEWO templates..."
+	@docker build -t ondewo-protoc-gen-doc:local .tmp-protoc-gen-doc-action
+	@echo "Generating documentation..."
+	@docker run --rm \
+		--user "$(shell id -u):$(shell id -g)" \
+		-v "$(shell pwd):/workspace" \
+		-w /workspace \
+		ondewo-protoc-gen-doc:local \
+		html,md index
+	@echo "✓ Documentation generated in docs/ directory"
+	@echo "  Open docs/index.html in your browser to view"
+
+clean_docs_builder: ## Remove the cloned protoc-gen-doc-action repo and Docker image
+	@echo "Cleaning up documentation builder..."
+	@rm -rf .tmp-protoc-gen-doc-action
+	@docker rmi ondewo-protoc-gen-doc:local 2>/dev/null || true
+	@echo "✓ Cleanup complete"
+
 TEST:
 	@echo "----------------------------------------------\nGITHUB_GH_TOKEN\n----------------------------------------------\n${GITHUB_GH_TOKEN}\n"
 	@echo "----------------------------------------------\nCURRENT_RELEASE_NOTES\n----------------------------------------------\n${CURRENT_RELEASE_NOTES}\n"

--- a/docs/index.html
+++ b/docs/index.html
@@ -36852,7 +36852,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.Caller" class="title-badge message">Caller</h3>
-        <p></p>
+        <p>Caller represents a caller instance that initiates outbound calls</p>
 
         
           <table class="field-table">
@@ -37117,7 +37117,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.DeleteCallersResponse" class="title-badge message">DeleteCallersResponse</h3>
-        <p></p>
+        <p>Response to delete multiple callers</p>
 
         
           <table class="field-table">
@@ -37227,7 +37227,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.DeleteListenersResponse" class="title-badge message">DeleteListenersResponse</h3>
-        <p></p>
+        <p>Response to delete multiple listeners</p>
 
         
           <table class="field-table">
@@ -37497,7 +37497,7 @@ Example: "current_index-1--page_size-20" </p></td>
                   <td>calls</td>
                   <td><a href="#ondewo.vtsi.Call">Call</a></td>
                   <td>repeated</td>
-                  <td><p>VoipInfos </p></td>
+                  <td><p>The list of calls returned in the response </p></td>
                 </tr>
               
                 <tr>
@@ -37590,7 +37590,7 @@ If there are no more results in the list, this field will be empty. </p></td>
         
       
         <h3 id="ondewo.vtsi.Listener" class="title-badge message">Listener</h3>
-        <p></p>
+        <p>Listener represents a listener instance that waits for incoming calls</p>
 
         
           <table class="field-table">
@@ -37657,14 +37657,14 @@ If there are no more results in the list, this field will be empty. </p></td>
                   <td>message_broker_services_activation_config</td>
                   <td><a href="#ondewo.vtsi.MessageBrokerServicesActivationConfig">MessageBrokerServicesActivationConfig</a></td>
                   <td></td>
-                  <td><p>Configuration of the RabbitMQ Message Broker </p></td>
+                  <td><p>Configuration of the Broker service activation </p></td>
                 </tr>
               
                 <tr>
                   <td>rabbit_mq_config</td>
                   <td><a href="#ondewo.vtsi.RabbitMqConfig">RabbitMqConfig</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Configuration of the RabbitMQ Message Broker </p></td>
                 </tr>
               
             </tbody>
@@ -37860,7 +37860,7 @@ Format: <pre><code>projects/&lt;uuid&gt;/agent</code></pre> </p></td>
                   <td>port_2</td>
                   <td><a href="#int32">int32</a></td>
                   <td></td>
-                  <td><p>port where the rabbit mq server runs </p></td>
+                  <td><p>secondary port where the rabbit mq server runs </p></td>
                 </tr>
               
                 <tr>
@@ -38185,7 +38185,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
                   <td>caller</td>
                   <td><a href="#ondewo.vtsi.Caller">Caller</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>The caller that was started </p></td>
                 </tr>
               
                 <tr>
@@ -38330,7 +38330,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
                   <td>listener</td>
                   <td><a href="#ondewo.vtsi.Listener">Listener</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>The listener that was started </p></td>
                 </tr>
               
                 <tr>
@@ -38476,7 +38476,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
                   <td>scheduled_caller</td>
                   <td><a href="#ondewo.vtsi.ScheduledCaller">ScheduledCaller</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>The scheduled caller that was created </p></td>
                 </tr>
               
                 <tr>
@@ -38732,7 +38732,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.StopCallersResponse" class="title-badge message">StopCallersResponse</h3>
-        <p></p>
+        <p>Response to stop multiple callers</p>
 
         
           <table class="field-table">
@@ -38906,7 +38906,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.StopListenersResponse" class="title-badge message">StopListenersResponse</h3>
-        <p></p>
+        <p>Response to stop multiple listeners</p>
 
         
           <table class="field-table">
@@ -39137,7 +39137,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
                   <td>transfer_call_responses</td>
                   <td><a href="#ondewo.vtsi.TransferCallResponse">TransferCallResponse</a></td>
                   <td>repeated</td>
-                  <td><p> </p></td>
+                  <td><p>The responses for each transfer call request </p></td>
                 </tr>
               
                 <tr>
@@ -39487,9 +39487,9 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
                   <td>vtsi_project</td>
                   <td><a href="#ondewo.vtsi.VtsiProject">VtsiProject</a></td>
                   <td></td>
-                  <td><p><p>VTSI project</p>
-<p>Recommended is to leave &quot;name&quot; empty. The project name here is optional.</p>
-<p>If no name is given a new parent name is created. The parent has the format:</p>
+                  <td><p>VTSI project
+Recommended is to leave &quot;name&quot; empty. The project name here is optional.
+If no name is given a new parent name is created. The parent has the format:
 <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> </p></td>
                 </tr>
               
@@ -40040,7 +40040,7 @@ Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
       <div id="ondewo/vtsi/projects.proto-enums" class="object-category">Enums</div>
       
         <h3 id="ondewo.vtsi.VtsiProjectSorting.VtsiProjectSortingField" class="title-badge enum">VtsiProjectSorting.VtsiProjectSortingField</h3>
-        <p>Enum to specify the sorting field for VTSI projects.</p>
+        <p>Enum to specify the sorting field for VTSI projects.</p><p>Enum defining the field by which VTSI projects can be sorted</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -36242,7 +36242,7 @@ The default value is None. </p></td>
       
         
         <h3 id="ondewo.vtsi.Calls" class="title-badge service">Calls</h3>
-        <p>ONDEWO VTSI API</p>
+        <p><p>ONDEWO VTSI API</p></p>
 
         
         <div id="ondewo.vtsi.Calls-methods" class="service-methods">Service Methods</div>
@@ -36251,153 +36251,153 @@ The default value is None. </p></td>
 
           <pre>rpc StartCaller (<a href="#ondewo.vtsi.StartCallerRequest">StartCallerRequest</a>) returns (<a href="#ondewo.vtsi.StartCallerResponse">StartCallerResponse)</a></pre>
 
-          start single caller instance for a specific nlu-project.
+          <p>Start single caller instance for a specific nlu-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.StartCallers" class="title-badge method">StartCallers</h4>
 
           <pre>rpc StartCallers (<a href="#ondewo.vtsi.StartCallersRequest">StartCallersRequest</a>) returns (<a href="#ondewo.vtsi.StartCallersResponse">StartCallersResponse)</a></pre>
 
-          start multiple ondewo-sip callers instances for a specific nlu-project.
+          <p>Start multiple ondewo-sip callers instances for a specific nlu-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.ListCallers" class="title-badge method">ListCallers</h4>
 
           <pre>rpc ListCallers (<a href="#ondewo.vtsi.ListCallersRequest">ListCallersRequest</a>) returns (<a href="#ondewo.vtsi.ListCallersResponse">ListCallersResponse)</a></pre>
 
-          lists all available callers
+          <p>Lists all available callers</p>
         
           <h4 id="ondewo.vtsi.Calls.GetCaller" class="title-badge method">GetCaller</h4>
 
           <pre>rpc GetCaller (<a href="#ondewo.vtsi.GetCallerRequest">GetCallerRequest</a>) returns (<a href="#ondewo.vtsi.Caller">Caller)</a></pre>
 
-          gets a caller
+          <p>Gets a caller</p>
         
           <h4 id="ondewo.vtsi.Calls.DeleteCaller" class="title-badge method">DeleteCaller</h4>
 
           <pre>rpc DeleteCaller (<a href="#ondewo.vtsi.DeleteCallerRequest">DeleteCallerRequest</a>) returns (<a href="#ondewo.vtsi.DeleteCallerResponse">DeleteCallerResponse)</a></pre>
 
-          deletes a caller
+          <p>Deletes a caller</p>
         
           <h4 id="ondewo.vtsi.Calls.DeleteCallers" class="title-badge method">DeleteCallers</h4>
 
           <pre>rpc DeleteCallers (<a href="#ondewo.vtsi.DeleteCallersRequest">DeleteCallersRequest</a>) returns (<a href="#ondewo.vtsi.DeleteCallersResponse">DeleteCallersResponse)</a></pre>
 
-          deletes multiple callers
+          <p>Deletes multiple callers</p>
         
           <h4 id="ondewo.vtsi.Calls.StopCaller" class="title-badge method">StopCaller</h4>
 
           <pre>rpc StopCaller (<a href="#ondewo.vtsi.StopCallerRequest">StopCallerRequest</a>) returns (<a href="#ondewo.vtsi.StopCallerResponse">StopCallerResponse)</a></pre>
 
-          stops a caller
+          <p>Stops a caller</p>
         
           <h4 id="ondewo.vtsi.Calls.StopCallers" class="title-badge method">StopCallers</h4>
 
           <pre>rpc StopCallers (<a href="#ondewo.vtsi.StopCallersRequest">StopCallersRequest</a>) returns (<a href="#ondewo.vtsi.StopCallersResponse">StopCallersResponse)</a></pre>
 
-          stops multiple callers
+          <p>Stops multiple callers</p>
         
           <h4 id="ondewo.vtsi.Calls.StartListener" class="title-badge method">StartListener</h4>
 
           <pre>rpc StartListener (<a href="#ondewo.vtsi.StartListenerRequest">StartListenerRequest</a>) returns (<a href="#ondewo.vtsi.StartListenerResponse">StartListenerResponse)</a></pre>
 
-          start single listener instance for a specific nlu-project.
+          <p>Start single listener instance for a specific nlu-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.StartListeners" class="title-badge method">StartListeners</h4>
 
           <pre>rpc StartListeners (<a href="#ondewo.vtsi.StartListenersRequest">StartListenersRequest</a>) returns (<a href="#ondewo.vtsi.StartListenersResponse">StartListenersResponse)</a></pre>
 
-          start multiple ondewo-sip listeners instances for a specific nlu-project.
+          <p>Start multiple ondewo-sip listeners instances for a specific nlu-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.StopListener" class="title-badge method">StopListener</h4>
 
           <pre>rpc StopListener (<a href="#ondewo.vtsi.StopListenerRequest">StopListenerRequest</a>) returns (<a href="#ondewo.vtsi.StopListenerResponse">StopListenerResponse)</a></pre>
 
-          stop a ondewo-sip listeners instances for a specific nlu-project.
+          <p>Stop a ondewo-sip listeners instances for a specific nlu-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.StopListeners" class="title-badge method">StopListeners</h4>
 
           <pre>rpc StopListeners (<a href="#ondewo.vtsi.StopListenersRequest">StopListenersRequest</a>) returns (<a href="#ondewo.vtsi.StopListenersResponse">StopListenersResponse)</a></pre>
 
-          stop multiple ondewo-sip listeners instances for a specific nlu-project.
+          <p>Stop multiple ondewo-sip listeners instances for a specific nlu-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.ListListeners" class="title-badge method">ListListeners</h4>
 
           <pre>rpc ListListeners (<a href="#ondewo.vtsi.ListListenersRequest">ListListenersRequest</a>) returns (<a href="#ondewo.vtsi.ListListenersResponse">ListListenersResponse)</a></pre>
 
-          lists all available listeners
+          <p>Lists all available listeners</p>
         
           <h4 id="ondewo.vtsi.Calls.GetListener" class="title-badge method">GetListener</h4>
 
           <pre>rpc GetListener (<a href="#ondewo.vtsi.GetListenerRequest">GetListenerRequest</a>) returns (<a href="#ondewo.vtsi.Listener">Listener)</a></pre>
 
-          gets a listener
+          <p>Gets a listener</p>
         
           <h4 id="ondewo.vtsi.Calls.DeleteListener" class="title-badge method">DeleteListener</h4>
 
           <pre>rpc DeleteListener (<a href="#ondewo.vtsi.DeleteListenerRequest">DeleteListenerRequest</a>) returns (<a href="#ondewo.vtsi.DeleteListenerResponse">DeleteListenerResponse)</a></pre>
 
-          deletes a listener
+          <p>Deletes a listener</p>
         
           <h4 id="ondewo.vtsi.Calls.DeleteListeners" class="title-badge method">DeleteListeners</h4>
 
           <pre>rpc DeleteListeners (<a href="#ondewo.vtsi.DeleteListenersRequest">DeleteListenersRequest</a>) returns (<a href="#ondewo.vtsi.DeleteListenersResponse">DeleteListenersResponse)</a></pre>
 
-          deletes multiple listeners
+          <p>Deletes multiple listeners</p>
         
           <h4 id="ondewo.vtsi.Calls.StartScheduledCaller" class="title-badge method">StartScheduledCaller</h4>
 
           <pre>rpc StartScheduledCaller (<a href="#ondewo.vtsi.StartScheduledCallerRequest">StartScheduledCallerRequest</a>) returns (<a href="#ondewo.vtsi.StartScheduledCallerResponse">StartScheduledCallerResponse)</a></pre>
 
-          start multiple ondewo-sip callers instances with schedules
+          <p>Start multiple ondewo-sip callers instances with schedules</p>
         
           <h4 id="ondewo.vtsi.Calls.StartScheduledCallers" class="title-badge method">StartScheduledCallers</h4>
 
           <pre>rpc StartScheduledCallers (<a href="#ondewo.vtsi.StartScheduledCallersRequest">StartScheduledCallersRequest</a>) returns (<a href="#ondewo.vtsi.StartScheduledCallersResponse">StartScheduledCallersResponse)</a></pre>
 
-          start multiple ondewo-sip callers instances with schedules
+          <p>Start multiple ondewo-sip callers instances with schedules</p>
         
           <h4 id="ondewo.vtsi.Calls.StopCall" class="title-badge method">StopCall</h4>
 
           <pre>rpc StopCall (<a href="#ondewo.vtsi.StopCallRequest">StopCallRequest</a>) returns (<a href="#ondewo.vtsi.StopCallResponse">StopCallResponse)</a></pre>
 
-          stop/kill a ondewo-sip listener or caller instance for a specific vtsi-project.
+          <p>Stop/kill a ondewo-sip listener or caller instance for a specific vtsi-project.</p>
         
           <h4 id="ondewo.vtsi.Calls.StopCalls" class="title-badge method">StopCalls</h4>
 
           <pre>rpc StopCalls (<a href="#ondewo.vtsi.StopCallsRequest">StopCallsRequest</a>) returns (<a href="#ondewo.vtsi.StopCallsResponse">StopCallsResponse)</a></pre>
 
-          stop/kill a list of ondewo-sip listener or caller instances for a specific vtsi-project.
-"stops both Listener and Caller calls"
+          <p>Stop/kill a list of ondewo-sip listener or caller instances for a specific vtsi-project.</p>
+<p>Stops both Listener and Caller calls</p>
         
           <h4 id="ondewo.vtsi.Calls.StopAllCalls" class="title-badge method">StopAllCalls</h4>
 
           <pre>rpc StopAllCalls (<a href="#ondewo.vtsi.StopAllCallsRequest">StopAllCallsRequest</a>) returns (<a href="#ondewo.vtsi.StopCallsResponse">StopCallsResponse)</a></pre>
 
-          stop/kill all ondewo-sip listener or caller instance for a specific nlu-project.
-"stops all Listener and Caller calls"
+          <p>Stop/kill all ondewo-sip listener or caller instance for a specific nlu-project.</p>
+<p>Stops all Listener and Caller calls</p>
         
           <h4 id="ondewo.vtsi.Calls.TransferCall" class="title-badge method">TransferCall</h4>
 
           <pre>rpc TransferCall (<a href="#ondewo.vtsi.TransferCallRequest">TransferCallRequest</a>) returns (<a href="#ondewo.vtsi.TransferCallResponse">TransferCallResponse)</a></pre>
 
-          Transfer a call from a listener to another
+          <p>Transfer a call from a listener to another</p>
         
           <h4 id="ondewo.vtsi.Calls.TransferCalls" class="title-badge method">TransferCalls</h4>
 
           <pre>rpc TransferCalls (<a href="#ondewo.vtsi.TransferCallsRequest">TransferCallsRequest</a>) returns (<a href="#ondewo.vtsi.TransferCallsResponse">TransferCallsResponse)</a></pre>
 
-          Transfer a call from a listener to another
+          <p>Transfer a call from a listener to another</p>
         
           <h4 id="ondewo.vtsi.Calls.GetCall" class="title-badge method">GetCall</h4>
 
           <pre>rpc GetCall (<a href="#ondewo.vtsi.GetCallRequest">GetCallRequest</a>) returns (<a href="#ondewo.vtsi.Call">Call)</a></pre>
 
-          get call log for single call instance
+          <p>Get call log for single call instance</p>
         
           <h4 id="ondewo.vtsi.Calls.ListCalls" class="title-badge method">ListCalls</h4>
 
           <pre>rpc ListCalls (<a href="#ondewo.vtsi.ListCallsRequest">ListCallsRequest</a>) returns (<a href="#ondewo.vtsi.ListCallsResponse">ListCallsResponse)</a></pre>
 
-          get call log for all call instances
+          <p>Get call log for all call instances</p>
         
 
         
@@ -36409,7 +36409,7 @@ The default value is None. </p></td>
       <div id="ondewo/vtsi/calls.proto-messages" class="object-category">Messages</div>
       
         <h3 id="ondewo.vtsi.AllServicesStatuses" class="title-badge message">AllServicesStatuses</h3>
-        <p>status of ondewo-sip instance</p>
+        <p>Status of ondewo-sip instance</p>
 
         
           <table class="field-table">
@@ -36547,7 +36547,7 @@ The default value is None. </p></td>
         
       
         <h3 id="ondewo.vtsi.BaseServiceConfig" class="title-badge message">BaseServiceConfig</h3>
-        <p>base configuration of services (ondewo-nlu, text-to-speech, speech-to-text, asterisk)</p>
+        <p>Base configuration of services (ondewo-nlu, text-to-speech, speech-to-text, asterisk)</p>
 
         
           <table class="field-table">
@@ -36730,7 +36730,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.CallFilter" class="title-badge message">CallFilter</h3>
-        <p></p>
+        <p>Definition of a CallFilter, representing filters for querying calls.</p>
 
         
           <table class="field-table">
@@ -36841,7 +36841,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
                   <td>platforms</td>
                   <td><a href="#ondewo.nlu.Intent.Message.Platform">ondewo.nlu.Intent.Message.Platform</a></td>
                   <td>repeated</td>
-                  <td><p>Optional: Platform responses sent to the user. Default is text: <code>Platform.PLATFORM_UNSPECIFIED</code>. </p></td>
+                  <td><p>Optional: Platform responses sent to the user. Default is text: <code>Platform.PLATFORM_UNSPECIFIED</code> </p></td>
                 </tr>
               
             </tbody>
@@ -37024,8 +37024,10 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
                   <td><a href="#bool">bool</a></td>
                   <td></td>
                   <td><p>Setting to activate if it is possible to send control messages
-a.) via RabbitMQ to remote control the system
-b.) via embeddings in NLU text responses </p></td>
+<ul>
+  <li>via RabbitMQ to remote control the system</li>
+  <li>via embeddings in NLU text responses</li>
+</ul> </p></td>
                 </tr>
               
             </tbody>
@@ -37256,7 +37258,7 @@ b.) via embeddings in NLU text responses </p></td>
         
       
         <h3 id="ondewo.vtsi.GetCallRequest" class="title-badge message">GetCallRequest</h3>
-        <p>request to get a call instance's call logs</p>
+        <p>Request to get a call instance&apos;s call logs</p>
 
         
           <table class="field-table">
@@ -37386,7 +37388,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>VTSI project name for which to perform the call.
-The format is: "projects/<project_uuid>/project". </p></td>
+The format is: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -37529,7 +37531,7 @@ If there are no more results in the list, this field will be empty. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>VTSI project name for which to perform the call.
-The format is: "projects/<project_uuid>/project". </p></td>
+The format is: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -37602,7 +37604,7 @@ If there are no more results in the list, this field will be empty. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>VTSI project name with which to perform the call of the form
-<code>projects/<project_uuid>/listeners/<listener_uuid></code> </p></td>
+<pre><code>projects/&lt;project_uuid&gt;/listeners/&lt;listener_uuid&gt;</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -37784,7 +37786,8 @@ Host, Port, and [Optional] GRPC cert </p></td>
                   <td>agent_name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>the resource name of the agent. Format: `projects/<uuid>/agent` </p></td>
+                  <td><p>The resource name of the agent.
+Format: <pre><code>projects/&lt;uuid&gt;/agent</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -38000,7 +38003,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
         
       
         <h3 id="ondewo.vtsi.ServiceStatus" class="title-badge message">ServiceStatus</h3>
-        <p>status of service</p>
+        <p>Status of service</p>
 
         
           <table class="field-table">
@@ -38031,7 +38034,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
         
       
         <h3 id="ondewo.vtsi.SipBaseConfig" class="title-badge message">SipBaseConfig</h3>
-        <p>The base config is for both the listener and caller .. If you only provide it you will get a listener</p><p>You will need to provide <code>SipCallerConfig</code> for the caller</p>
+        <p>The base config is for both the listener and caller. If you only provide it you will get a listener</p><p>You will need to provide <code>SipCallerConfig</code> for the caller</p>
 
         
           <table class="field-table">
@@ -38124,7 +38127,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
         
       
         <h3 id="ondewo.vtsi.StartCallerRequest" class="title-badge message">StartCallerRequest</h3>
-        <p>request for starting a caller</p>
+        <p>Request for starting a caller</p>
 
         
           <table class="field-table">
@@ -38269,7 +38272,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
         
       
         <h3 id="ondewo.vtsi.StartListenerRequest" class="title-badge message">StartListenerRequest</h3>
-        <p>request for starting a listener</p>
+        <p>Request for starting a listener</p>
 
         
           <table class="field-table">
@@ -38414,7 +38417,7 @@ TODO to be refactored with a more complex scheduling object </p></td>
         
       
         <h3 id="ondewo.vtsi.StartScheduledCallerRequest" class="title-badge message">StartScheduledCallerRequest</h3>
-        <p>request for starting a scheduled call</p>
+        <p>Request for starting a scheduled call</p>
 
         
           <table class="field-table">
@@ -39265,7 +39268,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
       
         
         <h3 id="ondewo.vtsi.Projects" class="title-badge service">Projects</h3>
-        <p>ONDEWO VTSI API</p>
+        <p><p>ONDEWO VTSI API</p></p>
 
         
         <div id="ondewo.vtsi.Projects-methods" class="service-methods">Service Methods</div>
@@ -39274,43 +39277,43 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
 
           <pre>rpc CreateVtsiProject (<a href="#ondewo.vtsi.CreateVtsiProjectRequest">CreateVtsiProjectRequest</a>) returns (<a href="#ondewo.vtsi.CreateVtsiProjectResponse">CreateVtsiProjectResponse)</a></pre>
 
-          Create a VTSI project with configs
+          <p>Create a VTSI project with configs</p>
         
           <h4 id="ondewo.vtsi.Projects.GetVtsiProject" class="title-badge method">GetVtsiProject</h4>
 
           <pre>rpc GetVtsiProject (<a href="#ondewo.vtsi.GetVtsiProjectRequest">GetVtsiProjectRequest</a>) returns (<a href="#ondewo.vtsi.VtsiProject">VtsiProject)</a></pre>
 
-          Get a VTSI project with configs
+          <p>Get a VTSI project with configs</p>
         
           <h4 id="ondewo.vtsi.Projects.UpdateVtsiProject" class="title-badge method">UpdateVtsiProject</h4>
 
           <pre>rpc UpdateVtsiProject (<a href="#ondewo.vtsi.UpdateVtsiProjectRequest">UpdateVtsiProjectRequest</a>) returns (<a href="#ondewo.vtsi.UpdateVtsiProjectResponse">UpdateVtsiProjectResponse)</a></pre>
 
-          Update a VTSI project with configs
+          <p>Update a VTSI project with configs</p>
         
           <h4 id="ondewo.vtsi.Projects.DeleteVtsiProject" class="title-badge method">DeleteVtsiProject</h4>
 
           <pre>rpc DeleteVtsiProject (<a href="#ondewo.vtsi.DeleteVtsiProjectRequest">DeleteVtsiProjectRequest</a>) returns (<a href="#ondewo.vtsi.DeleteVtsiProjectResponse">DeleteVtsiProjectResponse)</a></pre>
 
-          Delete a VTSI project with configs
+          <p>Delete a VTSI project with configs</p>
         
           <h4 id="ondewo.vtsi.Projects.DeployVtsiProject" class="title-badge method">DeployVtsiProject</h4>
 
           <pre>rpc DeployVtsiProject (<a href="#ondewo.vtsi.DeployVtsiProjectRequest">DeployVtsiProjectRequest</a>) returns (<a href="#ondewo.vtsi.DeployVtsiProjectResponse">DeployVtsiProjectResponse)</a></pre>
 
-          Deploy a VTSI project
+          <p>Deploy a VTSI project</p>
         
           <h4 id="ondewo.vtsi.Projects.UndeployVtsiProject" class="title-badge method">UndeployVtsiProject</h4>
 
           <pre>rpc UndeployVtsiProject (<a href="#ondewo.vtsi.UndeployVtsiProjectRequest">UndeployVtsiProjectRequest</a>) returns (<a href="#ondewo.vtsi.UndeployVtsiProjectResponse">UndeployVtsiProjectResponse)</a></pre>
 
-          Undeploy a VTSI project
+          <p>Undeploy a VTSI project</p>
         
           <h4 id="ondewo.vtsi.Projects.ListVtsiProjects" class="title-badge method">ListVtsiProjects</h4>
 
           <pre>rpc ListVtsiProjects (<a href="#ondewo.vtsi.ListVtsiProjectsRequest">ListVtsiProjectsRequest</a>) returns (<a href="#ondewo.vtsi.ListVtsiProjectsResponse">ListVtsiProjectsResponse)</a></pre>
 
-          Get a VTSI project with configs
+          <p>Get a VTSI project with configs</p>
         
 
         
@@ -39484,10 +39487,10 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
                   <td>vtsi_project</td>
                   <td><a href="#ondewo.vtsi.VtsiProject">VtsiProject</a></td>
                   <td></td>
-                  <td><p>VTSI project
-Recommended is to leave "name" empty. The project name here is optional.
-If no name is given a new parent name is created. The parent has the format:
-<pre><code>projects/&lt;project_uuid&gt;/project</code></pre>. </p></td>
+                  <td><p><p>VTSI project</p>
+<p>Recommended is to leave &quot;name&quot; empty. The project name here is optional.</p>
+<p>If no name is given a new parent name is created. The parent has the format:</p>
+<pre><code>projects/&lt;project_uuid&gt;/project</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -39713,8 +39716,8 @@ If not specified, the default behavior is to have no sorting. </p></td>
                   <td>nlu_agent_names</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>Optional. Filter based on associated NLU agents
-Format: `projects/<Project ID>/agent`. </p></td>
+                  <td><p>Optional. Filter based on associated NLU agents.
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
             </tbody>
@@ -39739,7 +39742,7 @@ Format: `projects/<Project ID>/agent`. </p></td>
                   <td><a href="#ondewo.vtsi.VtsiProject">VtsiProject</a></td>
                   <td>repeated</td>
                   <td><p>The list of VTSI projects returned in the response.
-Use the 'repeated' keyword to indicate that this field can contain multiple instances of VtsiProject. </p></td>
+Use the &apos;repeated&apos; keyword to indicate that this field can contain multiple instances of VtsiProject. </p></td>
                 </tr>
               
                 <tr>
@@ -39882,7 +39885,8 @@ If there are no more results in the list, this field will be empty. </p></td>
                   <td>name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Required. The project name. Format: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
+                  <td><p>Required. The project name.
+Format: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
 Only when a new VtsiProject is created the name can be undefined/empty </p></td>
                 </tr>
               
@@ -39974,8 +39978,8 @@ Only when a new VtsiProject is created the name can be undefined/empty </p></td>
                   <td>nlu_agent_names</td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
-                  <td><p>associated NLU agents
-Format: `projects/<Project ID>/agent`. </p></td>
+                  <td><p>Associated NLU agents.
+Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> </p></td>
                 </tr>
               
                 <tr>
@@ -40163,7 +40167,7 @@ in descending order based on the specified criteria.</p></td>
         </table>
       
         <h3 id="ondewo.vtsi.VtsiProjectView" class="title-badge enum">VtsiProjectView</h3>
-        <p>Structure of VTSI_PROJECT view</p><p>- CreateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</p><p>- UpdateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</p><p>- GetVTSI_PROJECT: VTSI_PROJECT_VIEW_FULL</p><p>- ListVTSI_PROJECTs: VTSI_PROJECT_VIEW_SHALLOW</p>
+        <p>Structure of VTSI_PROJECT view</p><p><ul></p><p><li>CreateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</li></p><p><li>UpdateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</li></p><p><li>GetVTSI_PROJECT: VTSI_PROJECT_VIEW_FULL</li></p><p><li>ListVTSI_PROJECTs: VTSI_PROJECT_VIEW_SHALLOW</li></p><p></ul></p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -36899,7 +36899,7 @@ For callers this is <pre><code>projects/&lt;project_uuid&gt;/callers/&lt;caller_
         
       
         <h3 id="ondewo.vtsi.CommonServicesConfig" class="title-badge message">CommonServicesConfig</h3>
-        <p>Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI</p><p>which are common for both listener and caller</p>
+        <p>Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI which are common for both listener and caller</p>
 
         
           <table class="field-table">

--- a/docs/index.md
+++ b/docs/index.md
@@ -12857,7 +12857,7 @@ Retrieves a list of custom phonemizers based on specific requirements. |
 <a name="ondewo.vtsi.AllServicesStatuses"></a>
 
 ### AllServicesStatuses
-status of ondewo-sip instance
+Status of ondewo-sip instance
 
 
 | Field | Type | Label | Description |
@@ -12923,7 +12923,7 @@ Configuration of the Minio Audio Object Store
 <a name="ondewo.vtsi.BaseServiceConfig"></a>
 
 ### BaseServiceConfig
-base configuration of services (ondewo-nlu, text-to-speech, speech-to-text, asterisk)
+Base configuration of services (ondewo-nlu, text-to-speech, speech-to-text, asterisk)
 
 
 | Field | Type | Label | Description |
@@ -12972,7 +12972,7 @@ Call
 <a name="ondewo.vtsi.CallFilter"></a>
 
 ### CallFilter
-
+Definition of a CallFilter, representing filters for querying calls.
 
 
 | Field | Type | Label | Description |
@@ -12991,7 +12991,7 @@ Call
 | end_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) | optional | Optional: End time of the log. |
 | duration_in_s_min | [float](#float) | optional | Optional: Match only sessions for which the duration in seconds is larger or equal. |
 | duration_in_s_max | [float](#float) | optional | Optional: Match only calls for which the duration in seconds is smaller or equal. |
-| platforms | [ondewo.nlu.Intent.Message.Platform](#ondewo.nlu.Intent.Message.Platform) | repeated | Optional: Platform responses sent to the user. Default is text: <code>Platform.PLATFORM_UNSPECIFIED</code>. |
+| platforms | [ondewo.nlu.Intent.Message.Platform](#ondewo.nlu.Intent.Message.Platform) | repeated | Optional: Platform responses sent to the user. Default is text: <code>Platform.PLATFORM_UNSPECIFIED</code> |
 
 
 
@@ -13064,7 +13064,7 @@ CSI configuration
 | t2s_vtsi_callbacks | [T2sVtsiCallbacks](#ondewo.vtsi.T2sVtsiCallbacks) |  | Callback for the Text-2-Speech platform |
 | audio_object_store_config | [AudioObjectStorageConfig](#ondewo.vtsi.AudioObjectStorageConfig) |  | Configuration of the Minio Audio Object Store |
 | message_broker_config | [MessageBrokerConfig](#ondewo.vtsi.MessageBrokerConfig) |  | Configuration of the RabbitMQ Message Broker |
-| activate_control_messages | [bool](#bool) |  | Setting to activate if it is possible to send control messages a.) via RabbitMQ to remote control the system b.) via embeddings in NLU text responses |
+| activate_control_messages | [bool](#bool) |  | Setting to activate if it is possible to send control messages <ul> <li>via RabbitMQ to remote control the system</li> <li>via embeddings in NLU text responses</li> </ul> |
 
 
 
@@ -13198,7 +13198,7 @@ Represents a request to delete multiple listeners.
 <a name="ondewo.vtsi.GetCallRequest"></a>
 
 ### GetCallRequest
-request to get a call instance's call logs
+Request to get a call instance&apos;s call logs
 
 
 | Field | Type | Label | Description |
@@ -13254,7 +13254,7 @@ Represents a request to list callers.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| vtsi_project_name | [string](#string) |  | VTSI project name for which to perform the call. The format is: "projects/<project_uuid>/project". |
+| vtsi_project_name | [string](#string) |  | VTSI project name for which to perform the call. The format is: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
 | page_token | [string](#string) | optional | Optional. The next_page_token value returned from a previous list request. Example: "current_index-1--page_size-20" |
 | call_view | [CallView](#ondewo.vtsi.CallView) | optional | you can specify the view to be shallow or full |
 
@@ -13320,7 +13320,7 @@ Represents a request to list listeners.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| vtsi_project_name | [string](#string) |  | VTSI project name for which to perform the call. The format is: "projects/<project_uuid>/project". |
+| vtsi_project_name | [string](#string) |  | VTSI project name for which to perform the call. The format is: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
 | page_token | [string](#string) | optional | Optional. The next_page_token value returned from a previous list request. Example: "current_index-1--page_size-20" |
 | call_view | [CallView](#ondewo.vtsi.CallView) | optional | you can specify the view to be shallow or full |
 
@@ -13353,7 +13353,7 @@ Represents the response for listing listeners.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | VTSI project name with which to perform the call of the form <code>projects/<project_uuid>/listeners/<listener_uuid></code> |
+| name | [string](#string) |  | VTSI project name with which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/listeners/&lt;listener_uuid&gt;</code></pre> |
 | call_name | [string](#string) |  | The call name that was assigned to the call <pre><code>projects/&lt;project_uuid&gt;/listeners/&lt;listener_uuid&gt;/calls/&lt;call_uuid&gt;</code></pre> |
 | sip_base_config | [SipBaseConfig](#ondewo.vtsi.SipBaseConfig) |  | SIP service configuration |
 | common_services_config | [CommonServicesConfig](#ondewo.vtsi.CommonServicesConfig) |  | Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI |
@@ -13425,7 +13425,7 @@ NLU Configuration
 | nlu_base_config | [BaseServiceConfig](#ondewo.vtsi.BaseServiceConfig) |  | Base config Host, Port, and [Optional] GRPC cert |
 | credentials | [Credentials](#ondewo.vtsi.Credentials) |  | Credentials with classical username and password |
 | auth_token | [string](#string) |  | Authentication token |
-| agent_name | [string](#string) |  | the resource name of the agent. Format: `projects/<uuid>/agent` |
+| agent_name | [string](#string) |  | The resource name of the agent. Format: <pre><code>projects/&lt;uuid&gt;/agent</code></pre> |
 | language_code | [string](#string) |  | language code in a two letter iso code, e.g. de, en, etc. |
 | initial_intent | [string](#string) |  | name of intent to trigger at the start of a call |
 | contexts | [ondewo.nlu.Context](#ondewo.nlu.Context) | repeated | ondewo-nlu list of contexts |
@@ -13510,7 +13510,7 @@ ScheduledCaller message - a Caller with a schedule when to start calling
 <a name="ondewo.vtsi.ServiceStatus"></a>
 
 ### ServiceStatus
-status of service
+Status of service
 
 
 | Field | Type | Label | Description |
@@ -13526,7 +13526,7 @@ status of service
 <a name="ondewo.vtsi.SipBaseConfig"></a>
 
 ### SipBaseConfig
-The base config is for both the listener and caller .. If you only provide it you will get a listener
+The base config is for both the listener and caller. If you only provide it you will get a listener
 You will need to provide <code>SipCallerConfig</code> for the caller
 
 
@@ -13575,7 +13575,7 @@ Configuration of the SIP caller
 <a name="ondewo.vtsi.StartCallerRequest"></a>
 
 ### StartCallerRequest
-request for starting a caller
+Request for starting a caller
 
 
 | Field | Type | Label | Description |
@@ -13642,7 +13642,7 @@ Response to the start caller request
 <a name="ondewo.vtsi.StartListenerRequest"></a>
 
 ### StartListenerRequest
-request for starting a listener
+Request for starting a listener
 
 
 | Field | Type | Label | Description |
@@ -13709,7 +13709,7 @@ Response to start multiple listeners
 <a name="ondewo.vtsi.StartScheduledCallerRequest"></a>
 
 ### StartScheduledCallerRequest
-request for starting a scheduled call
+Request for starting a scheduled call
 
 
 | Field | Type | Label | Description |
@@ -14125,35 +14125,35 @@ Call view options
 <a name="ondewo.vtsi.Calls"></a>
 
 ### Calls
-ONDEWO VTSI API
+<p>ONDEWO VTSI API</p>
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| StartCaller | [StartCallerRequest](#ondewo.vtsi.StartCallerRequest) | [StartCallerResponse](#ondewo.vtsi.StartCallerResponse) | start single caller instance for a specific nlu-project. |
-| StartCallers | [StartCallersRequest](#ondewo.vtsi.StartCallersRequest) | [StartCallersResponse](#ondewo.vtsi.StartCallersResponse) | start multiple ondewo-sip callers instances for a specific nlu-project. |
-| ListCallers | [ListCallersRequest](#ondewo.vtsi.ListCallersRequest) | [ListCallersResponse](#ondewo.vtsi.ListCallersResponse) | lists all available callers |
-| GetCaller | [GetCallerRequest](#ondewo.vtsi.GetCallerRequest) | [Caller](#ondewo.vtsi.Caller) | gets a caller |
-| DeleteCaller | [DeleteCallerRequest](#ondewo.vtsi.DeleteCallerRequest) | [DeleteCallerResponse](#ondewo.vtsi.DeleteCallerResponse) | deletes a caller |
-| DeleteCallers | [DeleteCallersRequest](#ondewo.vtsi.DeleteCallersRequest) | [DeleteCallersResponse](#ondewo.vtsi.DeleteCallersResponse) | deletes multiple callers |
-| StopCaller | [StopCallerRequest](#ondewo.vtsi.StopCallerRequest) | [StopCallerResponse](#ondewo.vtsi.StopCallerResponse) | stops a caller |
-| StopCallers | [StopCallersRequest](#ondewo.vtsi.StopCallersRequest) | [StopCallersResponse](#ondewo.vtsi.StopCallersResponse) | stops multiple callers |
-| StartListener | [StartListenerRequest](#ondewo.vtsi.StartListenerRequest) | [StartListenerResponse](#ondewo.vtsi.StartListenerResponse) | start single listener instance for a specific nlu-project. |
-| StartListeners | [StartListenersRequest](#ondewo.vtsi.StartListenersRequest) | [StartListenersResponse](#ondewo.vtsi.StartListenersResponse) | start multiple ondewo-sip listeners instances for a specific nlu-project. |
-| StopListener | [StopListenerRequest](#ondewo.vtsi.StopListenerRequest) | [StopListenerResponse](#ondewo.vtsi.StopListenerResponse) | stop a ondewo-sip listeners instances for a specific nlu-project. |
-| StopListeners | [StopListenersRequest](#ondewo.vtsi.StopListenersRequest) | [StopListenersResponse](#ondewo.vtsi.StopListenersResponse) | stop multiple ondewo-sip listeners instances for a specific nlu-project. |
-| ListListeners | [ListListenersRequest](#ondewo.vtsi.ListListenersRequest) | [ListListenersResponse](#ondewo.vtsi.ListListenersResponse) | lists all available listeners |
-| GetListener | [GetListenerRequest](#ondewo.vtsi.GetListenerRequest) | [Listener](#ondewo.vtsi.Listener) | gets a listener |
-| DeleteListener | [DeleteListenerRequest](#ondewo.vtsi.DeleteListenerRequest) | [DeleteListenerResponse](#ondewo.vtsi.DeleteListenerResponse) | deletes a listener |
-| DeleteListeners | [DeleteListenersRequest](#ondewo.vtsi.DeleteListenersRequest) | [DeleteListenersResponse](#ondewo.vtsi.DeleteListenersResponse) | deletes multiple listeners |
-| StartScheduledCaller | [StartScheduledCallerRequest](#ondewo.vtsi.StartScheduledCallerRequest) | [StartScheduledCallerResponse](#ondewo.vtsi.StartScheduledCallerResponse) | start multiple ondewo-sip callers instances with schedules |
-| StartScheduledCallers | [StartScheduledCallersRequest](#ondewo.vtsi.StartScheduledCallersRequest) | [StartScheduledCallersResponse](#ondewo.vtsi.StartScheduledCallersResponse) | start multiple ondewo-sip callers instances with schedules |
-| StopCall | [StopCallRequest](#ondewo.vtsi.StopCallRequest) | [StopCallResponse](#ondewo.vtsi.StopCallResponse) | stop/kill a ondewo-sip listener or caller instance for a specific vtsi-project. |
-| StopCalls | [StopCallsRequest](#ondewo.vtsi.StopCallsRequest) | [StopCallsResponse](#ondewo.vtsi.StopCallsResponse) | stop/kill a list of ondewo-sip listener or caller instances for a specific vtsi-project. "stops both Listener and Caller calls" |
-| StopAllCalls | [StopAllCallsRequest](#ondewo.vtsi.StopAllCallsRequest) | [StopCallsResponse](#ondewo.vtsi.StopCallsResponse) | stop/kill all ondewo-sip listener or caller instance for a specific nlu-project. "stops all Listener and Caller calls" |
-| TransferCall | [TransferCallRequest](#ondewo.vtsi.TransferCallRequest) | [TransferCallResponse](#ondewo.vtsi.TransferCallResponse) | Transfer a call from a listener to another |
-| TransferCalls | [TransferCallsRequest](#ondewo.vtsi.TransferCallsRequest) | [TransferCallsResponse](#ondewo.vtsi.TransferCallsResponse) | Transfer a call from a listener to another |
-| GetCall | [GetCallRequest](#ondewo.vtsi.GetCallRequest) | [Call](#ondewo.vtsi.Call) | get call log for single call instance |
-| ListCalls | [ListCallsRequest](#ondewo.vtsi.ListCallsRequest) | [ListCallsResponse](#ondewo.vtsi.ListCallsResponse) | get call log for all call instances |
+| StartCaller | [StartCallerRequest](#ondewo.vtsi.StartCallerRequest) | [StartCallerResponse](#ondewo.vtsi.StartCallerResponse) | <p>Start single caller instance for a specific nlu-project.</p> |
+| StartCallers | [StartCallersRequest](#ondewo.vtsi.StartCallersRequest) | [StartCallersResponse](#ondewo.vtsi.StartCallersResponse) | <p>Start multiple ondewo-sip callers instances for a specific nlu-project.</p> |
+| ListCallers | [ListCallersRequest](#ondewo.vtsi.ListCallersRequest) | [ListCallersResponse](#ondewo.vtsi.ListCallersResponse) | <p>Lists all available callers</p> |
+| GetCaller | [GetCallerRequest](#ondewo.vtsi.GetCallerRequest) | [Caller](#ondewo.vtsi.Caller) | <p>Gets a caller</p> |
+| DeleteCaller | [DeleteCallerRequest](#ondewo.vtsi.DeleteCallerRequest) | [DeleteCallerResponse](#ondewo.vtsi.DeleteCallerResponse) | <p>Deletes a caller</p> |
+| DeleteCallers | [DeleteCallersRequest](#ondewo.vtsi.DeleteCallersRequest) | [DeleteCallersResponse](#ondewo.vtsi.DeleteCallersResponse) | <p>Deletes multiple callers</p> |
+| StopCaller | [StopCallerRequest](#ondewo.vtsi.StopCallerRequest) | [StopCallerResponse](#ondewo.vtsi.StopCallerResponse) | <p>Stops a caller</p> |
+| StopCallers | [StopCallersRequest](#ondewo.vtsi.StopCallersRequest) | [StopCallersResponse](#ondewo.vtsi.StopCallersResponse) | <p>Stops multiple callers</p> |
+| StartListener | [StartListenerRequest](#ondewo.vtsi.StartListenerRequest) | [StartListenerResponse](#ondewo.vtsi.StartListenerResponse) | <p>Start single listener instance for a specific nlu-project.</p> |
+| StartListeners | [StartListenersRequest](#ondewo.vtsi.StartListenersRequest) | [StartListenersResponse](#ondewo.vtsi.StartListenersResponse) | <p>Start multiple ondewo-sip listeners instances for a specific nlu-project.</p> |
+| StopListener | [StopListenerRequest](#ondewo.vtsi.StopListenerRequest) | [StopListenerResponse](#ondewo.vtsi.StopListenerResponse) | <p>Stop a ondewo-sip listeners instances for a specific nlu-project.</p> |
+| StopListeners | [StopListenersRequest](#ondewo.vtsi.StopListenersRequest) | [StopListenersResponse](#ondewo.vtsi.StopListenersResponse) | <p>Stop multiple ondewo-sip listeners instances for a specific nlu-project.</p> |
+| ListListeners | [ListListenersRequest](#ondewo.vtsi.ListListenersRequest) | [ListListenersResponse](#ondewo.vtsi.ListListenersResponse) | <p>Lists all available listeners</p> |
+| GetListener | [GetListenerRequest](#ondewo.vtsi.GetListenerRequest) | [Listener](#ondewo.vtsi.Listener) | <p>Gets a listener</p> |
+| DeleteListener | [DeleteListenerRequest](#ondewo.vtsi.DeleteListenerRequest) | [DeleteListenerResponse](#ondewo.vtsi.DeleteListenerResponse) | <p>Deletes a listener</p> |
+| DeleteListeners | [DeleteListenersRequest](#ondewo.vtsi.DeleteListenersRequest) | [DeleteListenersResponse](#ondewo.vtsi.DeleteListenersResponse) | <p>Deletes multiple listeners</p> |
+| StartScheduledCaller | [StartScheduledCallerRequest](#ondewo.vtsi.StartScheduledCallerRequest) | [StartScheduledCallerResponse](#ondewo.vtsi.StartScheduledCallerResponse) | <p>Start multiple ondewo-sip callers instances with schedules</p> |
+| StartScheduledCallers | [StartScheduledCallersRequest](#ondewo.vtsi.StartScheduledCallersRequest) | [StartScheduledCallersResponse](#ondewo.vtsi.StartScheduledCallersResponse) | <p>Start multiple ondewo-sip callers instances with schedules</p> |
+| StopCall | [StopCallRequest](#ondewo.vtsi.StopCallRequest) | [StopCallResponse](#ondewo.vtsi.StopCallResponse) | <p>Stop/kill a ondewo-sip listener or caller instance for a specific vtsi-project.</p> |
+| StopCalls | [StopCallsRequest](#ondewo.vtsi.StopCallsRequest) | [StopCallsResponse](#ondewo.vtsi.StopCallsResponse) | <p>Stop/kill a list of ondewo-sip listener or caller instances for a specific vtsi-project.</p> <p>Stops both Listener and Caller calls</p> |
+| StopAllCalls | [StopAllCallsRequest](#ondewo.vtsi.StopAllCallsRequest) | [StopCallsResponse](#ondewo.vtsi.StopCallsResponse) | <p>Stop/kill all ondewo-sip listener or caller instance for a specific nlu-project.</p> <p>Stops all Listener and Caller calls</p> |
+| TransferCall | [TransferCallRequest](#ondewo.vtsi.TransferCallRequest) | [TransferCallResponse](#ondewo.vtsi.TransferCallResponse) | <p>Transfer a call from a listener to another</p> |
+| TransferCalls | [TransferCallsRequest](#ondewo.vtsi.TransferCallsRequest) | [TransferCallsResponse](#ondewo.vtsi.TransferCallsResponse) | <p>Transfer a call from a listener to another</p> |
+| GetCall | [GetCallRequest](#ondewo.vtsi.GetCallRequest) | [Call](#ondewo.vtsi.Call) | <p>Get call log for single call instance</p> |
+| ListCalls | [ListCallsRequest](#ondewo.vtsi.ListCallsRequest) | [ListCallsResponse](#ondewo.vtsi.ListCallsResponse) | <p>Get call log for all call instances</p> |
 
  <!-- end services -->
 
@@ -14230,7 +14230,7 @@ Request for creating a VTSI project
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| vtsi_project | [VtsiProject](#ondewo.vtsi.VtsiProject) |  | VTSI project Recommended is to leave "name" empty. The project name here is optional. If no name is given a new parent name is created. The parent has the format: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>. |
+| vtsi_project | [VtsiProject](#ondewo.vtsi.VtsiProject) |  | <p>VTSI project</p> <p>Recommended is to leave &quot;name&quot; empty. The project name here is optional.</p> <p>If no name is given a new parent name is created. The parent has the format:</p> <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
 | error_message | [string](#string) |  | error message if there are any. |
 
 
@@ -14345,7 +14345,7 @@ Request to get the list of agents
 | vtsi_project_view | [VtsiProjectView](#ondewo.vtsi.VtsiProjectView) |  | Optional. Specify the view of the returned VtsiProject (full view by default) |
 | page_token | [string](#string) | optional | Optional. The next_page_token value returned from a previous list request. Example: "current_index-1--page_size-20" |
 | vtsi_project_sorting | [VtsiProjectSorting](#ondewo.vtsi.VtsiProjectSorting) | optional | Optional. Field to define the sorting of the list of VTSI projects in the response. If not specified, the default behavior is to have no sorting. |
-| nlu_agent_names | [string](#string) | repeated | Optional. Filter based on associated NLU agents Format: `projects/<Project ID>/agent`. |
+| nlu_agent_names | [string](#string) | repeated | Optional. Filter based on associated NLU agents. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 
 
 
@@ -14360,7 +14360,7 @@ This is a protobuf message definition for the response of getting a list of VTSI
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| vtsi_projects | [VtsiProject](#ondewo.vtsi.VtsiProject) | repeated | The list of VTSI projects returned in the response. Use the 'repeated' keyword to indicate that this field can contain multiple instances of VtsiProject. |
+| vtsi_projects | [VtsiProject](#ondewo.vtsi.VtsiProject) | repeated | The list of VTSI projects returned in the response. Use the &apos;repeated&apos; keyword to indicate that this field can contain multiple instances of VtsiProject. |
 | next_page_token | [string](#string) |  | Token to retrieve the next page of results. This field is a string that holds a token for fetching the next page of results. If there are no more results in the list, this field will be empty. |
 
 
@@ -14451,7 +14451,7 @@ The VTSI project with its configuration setting
 | active_callers | [int32](#int32) |  | The number of active callers in this project. |
 | active_listeners | [int32](#int32) |  | The number of active listeners in this project. |
 | asterisk_port | [int32](#int32) |  | The port of the asterisk server |
-| nlu_agent_names | [string](#string) | repeated | associated NLU agents Format: `projects/<Project ID>/agent`. |
+| nlu_agent_names | [string](#string) | repeated | Associated NLU agents. Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre> |
 | deployed_callers | [int32](#int32) |  | The number of deployed callers in this project. |
 | deployed_listeners | [int32](#int32) |  | The number of deployed listeners in this project. |
 
@@ -14527,10 +14527,12 @@ Status of a VtsiProject.
 
 ### VtsiProjectView
 Structure of VTSI_PROJECT view
-- CreateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW
-- UpdateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW
-- GetVTSI_PROJECT: VTSI_PROJECT_VIEW_FULL
-- ListVTSI_PROJECTs: VTSI_PROJECT_VIEW_SHALLOW
+<ul>
+  <li>CreateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</li>
+  <li>UpdateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</li>
+  <li>GetVTSI_PROJECT: VTSI_PROJECT_VIEW_FULL</li>
+  <li>ListVTSI_PROJECTs: VTSI_PROJECT_VIEW_SHALLOW</li>
+</ul>
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -14548,17 +14550,17 @@ Structure of VTSI_PROJECT view
 <a name="ondewo.vtsi.Projects"></a>
 
 ### Projects
-ONDEWO VTSI API
+<p>ONDEWO VTSI API</p>
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateVtsiProject | [CreateVtsiProjectRequest](#ondewo.vtsi.CreateVtsiProjectRequest) | [CreateVtsiProjectResponse](#ondewo.vtsi.CreateVtsiProjectResponse) | Create a VTSI project with configs |
-| GetVtsiProject | [GetVtsiProjectRequest](#ondewo.vtsi.GetVtsiProjectRequest) | [VtsiProject](#ondewo.vtsi.VtsiProject) | Get a VTSI project with configs |
-| UpdateVtsiProject | [UpdateVtsiProjectRequest](#ondewo.vtsi.UpdateVtsiProjectRequest) | [UpdateVtsiProjectResponse](#ondewo.vtsi.UpdateVtsiProjectResponse) | Update a VTSI project with configs |
-| DeleteVtsiProject | [DeleteVtsiProjectRequest](#ondewo.vtsi.DeleteVtsiProjectRequest) | [DeleteVtsiProjectResponse](#ondewo.vtsi.DeleteVtsiProjectResponse) | Delete a VTSI project with configs |
-| DeployVtsiProject | [DeployVtsiProjectRequest](#ondewo.vtsi.DeployVtsiProjectRequest) | [DeployVtsiProjectResponse](#ondewo.vtsi.DeployVtsiProjectResponse) | Deploy a VTSI project |
-| UndeployVtsiProject | [UndeployVtsiProjectRequest](#ondewo.vtsi.UndeployVtsiProjectRequest) | [UndeployVtsiProjectResponse](#ondewo.vtsi.UndeployVtsiProjectResponse) | Undeploy a VTSI project |
-| ListVtsiProjects | [ListVtsiProjectsRequest](#ondewo.vtsi.ListVtsiProjectsRequest) | [ListVtsiProjectsResponse](#ondewo.vtsi.ListVtsiProjectsResponse) | Get a VTSI project with configs |
+| CreateVtsiProject | [CreateVtsiProjectRequest](#ondewo.vtsi.CreateVtsiProjectRequest) | [CreateVtsiProjectResponse](#ondewo.vtsi.CreateVtsiProjectResponse) | <p>Create a VTSI project with configs</p> |
+| GetVtsiProject | [GetVtsiProjectRequest](#ondewo.vtsi.GetVtsiProjectRequest) | [VtsiProject](#ondewo.vtsi.VtsiProject) | <p>Get a VTSI project with configs</p> |
+| UpdateVtsiProject | [UpdateVtsiProjectRequest](#ondewo.vtsi.UpdateVtsiProjectRequest) | [UpdateVtsiProjectResponse](#ondewo.vtsi.UpdateVtsiProjectResponse) | <p>Update a VTSI project with configs</p> |
+| DeleteVtsiProject | [DeleteVtsiProjectRequest](#ondewo.vtsi.DeleteVtsiProjectRequest) | [DeleteVtsiProjectResponse](#ondewo.vtsi.DeleteVtsiProjectResponse) | <p>Delete a VTSI project with configs</p> |
+| DeployVtsiProject | [DeployVtsiProjectRequest](#ondewo.vtsi.DeployVtsiProjectRequest) | [DeployVtsiProjectResponse](#ondewo.vtsi.DeployVtsiProjectResponse) | <p>Deploy a VTSI project</p> |
+| UndeployVtsiProject | [UndeployVtsiProjectRequest](#ondewo.vtsi.UndeployVtsiProjectRequest) | [UndeployVtsiProjectResponse](#ondewo.vtsi.UndeployVtsiProjectResponse) | <p>Undeploy a VTSI project</p> |
+| ListVtsiProjects | [ListVtsiProjectsRequest](#ondewo.vtsi.ListVtsiProjectsRequest) | [ListVtsiProjectsResponse](#ondewo.vtsi.ListVtsiProjectsResponse) | <p>Get a VTSI project with configs</p> |
 
  <!-- end services -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13001,7 +13001,7 @@ Definition of a CallFilter, representing filters for querying calls.
 <a name="ondewo.vtsi.Caller"></a>
 
 ### Caller
-
+Caller represents a caller instance that initiates outbound calls
 
 
 | Field | Type | Label | Description |
@@ -13120,7 +13120,7 @@ Represents a request to delete multiple callers.
 <a name="ondewo.vtsi.DeleteCallersResponse"></a>
 
 ### DeleteCallersResponse
-
+Response to delete multiple callers
 
 
 | Field | Type | Label | Description |
@@ -13182,7 +13182,7 @@ Represents a request to delete multiple listeners.
 <a name="ondewo.vtsi.DeleteListenersResponse"></a>
 
 ### DeleteListenersResponse
-
+Response to delete multiple listeners
 
 
 | Field | Type | Label | Description |
@@ -13304,7 +13304,7 @@ Response to list all VoipInfos
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| calls | [Call](#ondewo.vtsi.Call) | repeated | VoipInfos |
+| calls | [Call](#ondewo.vtsi.Call) | repeated | The list of calls returned in the response |
 | next_page_token | [string](#string) |  | Token to retrieve the next page of results. This field is a string that holds a token for fetching the next page of results. If there are no more results in the list, this field will be empty. |
 
 
@@ -13348,7 +13348,7 @@ Represents the response for listing listeners.
 <a name="ondewo.vtsi.Listener"></a>
 
 ### Listener
-
+Listener represents a listener instance that waits for incoming calls
 
 
 | Field | Type | Label | Description |
@@ -13372,8 +13372,8 @@ Configuration of the RabbitMQ Message Broker
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | activate_message_broker | [bool](#bool) |  | Should the broker be activated or not |
-| message_broker_services_activation_config | [MessageBrokerServicesActivationConfig](#ondewo.vtsi.MessageBrokerServicesActivationConfig) |  | Configuration of the RabbitMQ Message Broker |
-| rabbit_mq_config | [RabbitMqConfig](#ondewo.vtsi.RabbitMqConfig) |  |  |
+| message_broker_services_activation_config | [MessageBrokerServicesActivationConfig](#ondewo.vtsi.MessageBrokerServicesActivationConfig) |  | Configuration of the Broker service activation |
+| rabbit_mq_config | [RabbitMqConfig](#ondewo.vtsi.RabbitMqConfig) |  | Configuration of the RabbitMQ Message Broker |
 
 
 
@@ -13447,7 +13447,7 @@ Configuration of the RabbitMQ Message Broker
 | ----- | ---- | ----- | ----------- |
 | host | [string](#string) |  | host where the rabbit mq server runs |
 | port | [int32](#int32) |  | port where the rabbit mq server runs |
-| port_2 | [int32](#int32) |  | port where the rabbit mq server runs |
+| port_2 | [int32](#int32) |  | secondary port where the rabbit mq server runs |
 | user | [string](#string) |  | user of server |
 | password | [string](#string) |  | password of server |
 
@@ -13598,7 +13598,7 @@ Response to start multiple listeners
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | vtsi_project_name | [string](#string) |  | VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
-| caller | [Caller](#ondewo.vtsi.Caller) |  |  |
+| caller | [Caller](#ondewo.vtsi.Caller) |  | The caller that was started |
 | error_message | [string](#string) |  | error message if you have any so if it's unhealthy |
 
 
@@ -13665,7 +13665,7 @@ Response to start multiple listeners
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | vtsi_project_name | [string](#string) |  | VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
-| listener | [Listener](#ondewo.vtsi.Listener) |  |  |
+| listener | [Listener](#ondewo.vtsi.Listener) |  | The listener that was started |
 | error_message | [string](#string) |  | error message if you have any so if it's unhealthy |
 
 
@@ -13732,7 +13732,7 @@ Response to start multiple listeners
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | vtsi_project_name | [string](#string) |  | VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
-| scheduled_caller | [ScheduledCaller](#ondewo.vtsi.ScheduledCaller) |  |  |
+| scheduled_caller | [ScheduledCaller](#ondewo.vtsi.ScheduledCaller) |  | The scheduled caller that was created |
 | error_message | [string](#string) |  | error message if you have any so if it's unhealthy |
 
 
@@ -13869,7 +13869,7 @@ Represents a request to stop multiple callers.
 <a name="ondewo.vtsi.StopCallersResponse"></a>
 
 ### StopCallersResponse
-
+Response to stop multiple callers
 
 
 | Field | Type | Label | Description |
@@ -13963,7 +13963,7 @@ Represents a request to stop multiple listeners.
 <a name="ondewo.vtsi.StopListenersResponse"></a>
 
 ### StopListenersResponse
-
+Response to stop multiple listeners
 
 
 | Field | Type | Label | Description |
@@ -14068,7 +14068,7 @@ Response to transfer a call to a phone number or voip number
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | vtsi_project_name | [string](#string) |  | VTSI project name with which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
-| transfer_call_responses | [TransferCallResponse](#ondewo.vtsi.TransferCallResponse) | repeated |  |
+| transfer_call_responses | [TransferCallResponse](#ondewo.vtsi.TransferCallResponse) | repeated | The responses for each transfer call request |
 | error_message | [string](#string) |  | overall error message if you have any so if it's unhealthy |
 
 
@@ -14230,7 +14230,7 @@ Request for creating a VTSI project
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| vtsi_project | [VtsiProject](#ondewo.vtsi.VtsiProject) |  | <p>VTSI project</p> <p>Recommended is to leave &quot;name&quot; empty. The project name here is optional.</p> <p>If no name is given a new parent name is created. The parent has the format:</p> <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
+| vtsi_project | [VtsiProject](#ondewo.vtsi.VtsiProject) |  | VTSI project Recommended is to leave &quot;name&quot; empty. The project name here is optional. If no name is given a new parent name is created. The parent has the format: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre> |
 | error_message | [string](#string) |  | error message if there are any. |
 
 
@@ -14482,6 +14482,7 @@ This protobuf message defines the sorting order for VTSI (Virtual Test System In
 
 ### VtsiProjectSorting.VtsiProjectSortingField
 Enum to specify the sorting field for VTSI projects.
+Enum defining the field by which VTSI projects can be sorted
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13019,8 +13019,7 @@ Caller represents a caller instance that initiates outbound calls
 <a name="ondewo.vtsi.CommonServicesConfig"></a>
 
 ### CommonServicesConfig
-Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI
-which are common for both listener and caller
+Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI which are common for both listener and caller
 
 
 | Field | Type | Label | Description |

--- a/ondewo/vtsi/calls.proto
+++ b/ondewo/vtsi/calls.proto
@@ -296,11 +296,11 @@ message MessageBrokerConfig{
     // Should the broker be activated or not
     bool activate_message_broker = 1;
 
-    // Configuration of the RabbitMQ Message Broker
+    // Configuration of the Broker service activation
     MessageBrokerServicesActivationConfig message_broker_services_activation_config = 2;
 
-    // Configuration of the RabbitMQ Message Broker
     oneof message_broker_config{
+        // Configuration of the RabbitMQ Message Broker
         RabbitMqConfig rabbit_mq_config = 3;
     }
 }
@@ -330,7 +330,7 @@ message RabbitMqConfig{
     // port where the rabbit mq server runs
     int32 port = 2;
 
-    // port where the rabbit mq server runs
+    // secondary port where the rabbit mq server runs
     int32 port_2 = 3;
 
     // user of server
@@ -374,6 +374,7 @@ message T2sVtsiCallbacks{
 
 }
 
+// Listener represents a listener instance that waits for incoming calls
 message Listener {
 
     // VTSI project name with which to perform the call of the form
@@ -392,6 +393,7 @@ message Listener {
 
 }
 
+// Caller represents a caller instance that initiates outbound calls
 message Caller {
 
     // Caller name with which to perform the call of the form
@@ -430,6 +432,7 @@ message StartListenerResponse {
     // VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     string vtsi_project_name = 1;
 
+    // The listener that was started
     Listener listener = 2;
 
     // error message if you have any so if it's unhealthy
@@ -481,6 +484,7 @@ message StartCallerResponse {
     // VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     string vtsi_project_name = 1;
 
+    // The caller that was started
     Caller caller = 2;
 
     // error message if you have any so if it's unhealthy
@@ -621,6 +625,7 @@ message StopListenersRequest {
 
 }
 
+// Response to stop multiple listeners
 message StopListenersResponse {
 
     // responses to stop listeners
@@ -658,6 +663,7 @@ message StopCallersRequest {
 
 }
 
+// Response to stop multiple callers
 message StopCallersResponse {
 
     // responses to stop callers
@@ -695,6 +701,7 @@ message DeleteListenersRequest {
 
 }
 
+// Response to delete multiple listeners
 message DeleteListenersResponse {
 
     // responses to delete listeners
@@ -733,6 +740,7 @@ message DeleteCallersRequest {
 
 }
 
+// Response to delete multiple callers
 message DeleteCallersResponse {
 
     // responses to delete callers
@@ -786,6 +794,7 @@ message StartScheduledCallerResponse {
     // VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     string vtsi_project_name = 1;
 
+    // The scheduled caller that was created
     ScheduledCaller scheduled_caller = 2;
 
     // error message if you have any so if it's unhealthy
@@ -924,6 +933,7 @@ message TransferCallsResponse {
     // VTSI project name with which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     string vtsi_project_name = 1;
 
+    // The responses for each transfer call request
     repeated TransferCallResponse transfer_call_responses = 2;
 
     // overall error message if you have any so if it's unhealthy
@@ -1122,7 +1132,7 @@ message ListCallsRequest{
 // Response to list all VoipInfos
 message ListCallsResponse{
 
-    // VoipInfos
+    // The list of calls returned in the response
     repeated Call calls = 1;
 
     // Token to retrieve the next page of results.

--- a/ondewo/vtsi/calls.proto
+++ b/ondewo/vtsi/calls.proto
@@ -26,93 +26,93 @@ import "ondewo/t2s/text-to-speech.proto";
 import "ondewo/sip/sip.proto";
 
 
-// ONDEWO VTSI API
+// <p>ONDEWO VTSI API</p>
 service Calls {
 
     //////////////////////////////////////////////////////////////////////////////
     // Caller and Listener endpoints
     //////////////////////////////////////////////////////////////////////////////
 
-    // start single caller instance for a specific nlu-project.
+    // <p>Start single caller instance for a specific nlu-project.</p>
     rpc StartCaller (StartCallerRequest) returns (StartCallerResponse);
 
-    // start multiple ondewo-sip callers instances for a specific nlu-project.
+    // <p>Start multiple ondewo-sip callers instances for a specific nlu-project.</p>
     rpc StartCallers (StartCallersRequest) returns (StartCallersResponse);
 
-    // lists all available callers
+    // <p>Lists all available callers</p>
     rpc ListCallers (ListCallersRequest) returns (ListCallersResponse);
 
-    // gets a caller
+    // <p>Gets a caller</p>
     rpc GetCaller (GetCallerRequest) returns (Caller);
 
-    // deletes a caller
+    // <p>Deletes a caller</p>
     rpc DeleteCaller (DeleteCallerRequest) returns (DeleteCallerResponse);
 
-    // deletes multiple callers
+    // <p>Deletes multiple callers</p>
     rpc DeleteCallers (DeleteCallersRequest) returns (DeleteCallersResponse);
 
-    // stops a caller
+    // <p>Stops a caller</p>
     rpc StopCaller (StopCallerRequest) returns (StopCallerResponse);
 
-    // stops multiple callers
+    // <p>Stops multiple callers</p>
     rpc StopCallers (StopCallersRequest) returns (StopCallersResponse);
 
-    // start single listener instance for a specific nlu-project.
+    // <p>Start single listener instance for a specific nlu-project.</p>
     rpc StartListener (StartListenerRequest) returns (StartListenerResponse);
 
-    // start multiple ondewo-sip listeners instances for a specific nlu-project.
+    // <p>Start multiple ondewo-sip listeners instances for a specific nlu-project.</p>
     rpc StartListeners (StartListenersRequest) returns (StartListenersResponse);
 
-    // stop a ondewo-sip listeners instances for a specific nlu-project.
+    // <p>Stop a ondewo-sip listeners instances for a specific nlu-project.</p>
     rpc StopListener (StopListenerRequest) returns (StopListenerResponse);
 
-    // stop multiple ondewo-sip listeners instances for a specific nlu-project.
+    // <p>Stop multiple ondewo-sip listeners instances for a specific nlu-project.</p>
     rpc StopListeners (StopListenersRequest) returns (StopListenersResponse);
 
-    // lists all available listeners
+    // <p>Lists all available listeners</p>
     rpc ListListeners (ListListenersRequest) returns (ListListenersResponse);
 
-    // gets a listener
+    // <p>Gets a listener</p>
     rpc GetListener (GetListenerRequest) returns (Listener);
 
-    // deletes a listener
+    // <p>Deletes a listener</p>
     rpc DeleteListener (DeleteListenerRequest) returns (DeleteListenerResponse);
 
-    // deletes multiple listeners
+    // <p>Deletes multiple listeners</p>
     rpc DeleteListeners (DeleteListenersRequest) returns (DeleteListenersResponse);
 
-    // start multiple ondewo-sip callers instances with schedules
+    // <p>Start multiple ondewo-sip callers instances with schedules</p>
     rpc StartScheduledCaller (StartScheduledCallerRequest) returns (StartScheduledCallerResponse);
 
-    // start multiple ondewo-sip callers instances with schedules
+    // <p>Start multiple ondewo-sip callers instances with schedules</p>
     rpc StartScheduledCallers (StartScheduledCallersRequest) returns (StartScheduledCallersResponse);
 
-    // stop/kill a ondewo-sip listener or caller instance for a specific vtsi-project.
+    // <p>Stop/kill a ondewo-sip listener or caller instance for a specific vtsi-project.</p>
     rpc StopCall (StopCallRequest) returns (StopCallResponse);
 
-    // stop/kill a list of ondewo-sip listener or caller instances for a specific vtsi-project.
-    // "stops both Listener and Caller calls"
+    // <p>Stop/kill a list of ondewo-sip listener or caller instances for a specific vtsi-project.</p>
+    // <p>Stops both Listener and Caller calls</p>
     rpc StopCalls (StopCallsRequest) returns (StopCallsResponse);
 
-    // stop/kill all ondewo-sip listener or caller instance for a specific nlu-project.
-    // "stops all Listener and Caller calls"
+    // <p>Stop/kill all ondewo-sip listener or caller instance for a specific nlu-project.</p>
+    // <p>Stops all Listener and Caller calls</p>
     rpc StopAllCalls (StopAllCallsRequest) returns (StopCallsResponse);
 
-    // Transfer a call from a listener to another
+    // <p>Transfer a call from a listener to another</p>
     rpc TransferCall (TransferCallRequest) returns (TransferCallResponse);
 
-    // Transfer a call from a listener to another
+    // <p>Transfer a call from a listener to another</p>
     rpc TransferCalls (TransferCallsRequest) returns (TransferCallsResponse);
 
-    // get call log for single call instance
+    // <p>Get call log for single call instance</p>
     rpc GetCall (GetCallRequest) returns (Call);
 
-    // get call log for all call instances
+    // <p>Get call log for all call instances</p>
     rpc ListCalls (ListCallsRequest) returns (ListCallsResponse);
 
 }
 
-// base configuration of services (ondewo-nlu, text-to-speech, speech-to-text, asterisk)
+// Base configuration of services (ondewo-nlu, text-to-speech, speech-to-text, asterisk)
 message BaseServiceConfig{
 
     // service host IP
@@ -152,7 +152,8 @@ message NluVtsiConfig{
         string auth_token = 3;
     }
 
-    // the resource name of the agent. Format: `projects/<uuid>/agent`
+    // The resource name of the agent.
+    // Format: <pre><code>projects/&lt;uuid&gt;/agent</code></pre>
     string agent_name = 4;
 
     // language code in a two letter iso code, e.g. de, en, etc.
@@ -217,7 +218,7 @@ message CommonServicesConfig{
 
 }
 
-// The base config is for both the listener and caller .. If you only provide it you will get a listener
+// The base config is for both the listener and caller. If you only provide it you will get a listener
 // You will need to provide <code>SipCallerConfig</code> for the caller
 message SipBaseConfig{
 
@@ -260,8 +261,10 @@ message CsiVtsiConfig{
     MessageBrokerConfig message_broker_config = 5;
 
     // Setting to activate if it is possible to send control messages
-    // a.) via RabbitMQ to remote control the system
-    // b.) via embeddings in NLU text responses
+    // <ul>
+    //   <li>via RabbitMQ to remote control the system</li>
+    //   <li>via embeddings in NLU text responses</li>
+    // </ul>
     bool activate_control_messages = 6;
 
 }
@@ -374,7 +377,7 @@ message T2sVtsiCallbacks{
 message Listener {
 
     // VTSI project name with which to perform the call of the form
-    // <code>projects/<project_uuid>/listeners/<listener_uuid></code>
+    // <pre><code>projects/&lt;project_uuid&gt;/listeners/&lt;listener_uuid&gt;</code></pre>
     string name = 1;
 
     // The call name that was assigned to the call
@@ -407,7 +410,7 @@ message Caller {
 }
 
 
-// request for starting a listener
+// Request for starting a listener
 message StartListenerRequest {
 
     // VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
@@ -458,7 +461,7 @@ message StartListenersResponse {
 
 }
 
-// request for starting a caller
+// Request for starting a caller
 message StartCallerRequest {
 
     // VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
@@ -515,7 +518,7 @@ message StartCallersResponse {
 message ListCallersRequest {
 
     // VTSI project name for which to perform the call.
-    // The format is: "projects/<project_uuid>/project".
+    // The format is: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     string vtsi_project_name = 1;
 
     // Optional. The next_page_token value returned from a previous list request.
@@ -553,7 +556,7 @@ message GetCallerRequest {
 message ListListenersRequest {
 
     // VTSI project name for which to perform the call.
-    // The format is: "projects/<project_uuid>/project".
+    // The format is: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     string vtsi_project_name = 1;
 
     // Optional. The next_page_token value returned from a previous list request.
@@ -740,7 +743,7 @@ message DeleteCallersResponse {
 
 }
 
-// request for starting a scheduled call
+// Request for starting a scheduled call
 message StartScheduledCallerRequest {
 
     // VTSI project name which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
@@ -928,7 +931,7 @@ message TransferCallsResponse {
 
 }
 
-// request to get a call instance's call logs
+// Request to get a call instance&apos;s call logs
 message GetCallRequest {
 
     // VTSI project name with which to perform the call of the form <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
@@ -1048,7 +1051,6 @@ message Call {
 }
 
 // Definition of a CallFilter, representing filters for querying calls.
-
 message CallFilter {
 
     // Optional: Filter by call names.
@@ -1093,7 +1095,7 @@ message CallFilter {
     // Optional: Match only calls for which the duration in seconds is smaller or equal.
     optional float duration_in_s_max = 14;
 
-    // Optional: Platform responses sent to the user. Default is text: <code>Platform.PLATFORM_UNSPECIFIED</code>.
+    // Optional: Platform responses sent to the user. Default is text: <code>Platform.PLATFORM_UNSPECIFIED</code>
     repeated ondewo.nlu.Intent.Message.Platform platforms = 15;
 
 }
@@ -1130,7 +1132,7 @@ message ListCallsResponse{
 
 }
 
-// status of ondewo-sip instance
+// Status of ondewo-sip instance
 message AllServicesStatuses {
 
     // health status for sip
@@ -1149,7 +1151,7 @@ message AllServicesStatuses {
     ServiceStatus status_tts = 5;
 }
 
-// status of service
+// Status of service
 message ServiceStatus {
 
     // health status

--- a/ondewo/vtsi/calls.proto
+++ b/ondewo/vtsi/calls.proto
@@ -200,8 +200,7 @@ message AsteriskConfig{
     BaseServiceConfig asterisk_base_config = 1;
 }
 
-// Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI
-// which are common for both listener and caller
+// Service Configs of Speech-2-Text, NLU, Text-2-Speech and CSI which are common for both listener and caller
 message CommonServicesConfig{
 
     // speech-to-text service configuration

--- a/ondewo/vtsi/projects.proto
+++ b/ondewo/vtsi/projects.proto
@@ -197,9 +197,9 @@ message AsteriskConfigs{
 // Request for creating a VTSI project
 message CreateVtsiProjectRequest{
 
-    // <p>VTSI project</p>
-    // <p>Recommended is to leave &quot;name&quot; empty. The project name here is optional.</p>
-    // <p>If no name is given a new parent name is created. The parent has the format:</p>
+    // VTSI project
+    // Recommended is to leave &quot;name&quot; empty. The project name here is optional.
+    // If no name is given a new parent name is created. The parent has the format:
     // <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     VtsiProject vtsi_project = 1;
 
@@ -263,6 +263,7 @@ message ListVtsiProjectsResponse {
 message VtsiProjectSorting {
 
     // Enum to specify the sorting field for VTSI projects.
+    // Enum defining the field by which VTSI projects can be sorted
     enum VtsiProjectSortingField {
 
         // No sorting

--- a/ondewo/vtsi/projects.proto
+++ b/ondewo/vtsi/projects.proto
@@ -18,32 +18,32 @@ package ondewo.vtsi;
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-// ONDEWO VTSI API
+// <p>ONDEWO VTSI API</p>
 service Projects {
 
     //////////////////////////////////////////////////////////////////////////////
     // Project endpoints
     //////////////////////////////////////////////////////////////////////////////
 
-    // Create a VTSI project with configs
+    // <p>Create a VTSI project with configs</p>
     rpc CreateVtsiProject (CreateVtsiProjectRequest) returns (CreateVtsiProjectResponse);
 
-    // Get a VTSI project with configs
+    // <p>Get a VTSI project with configs</p>
     rpc GetVtsiProject (GetVtsiProjectRequest) returns (VtsiProject);
 
-    // Update a VTSI project with configs
+    // <p>Update a VTSI project with configs</p>
     rpc UpdateVtsiProject (UpdateVtsiProjectRequest) returns (UpdateVtsiProjectResponse);
 
-    // Delete a VTSI project with configs
+    // <p>Delete a VTSI project with configs</p>
     rpc DeleteVtsiProject (DeleteVtsiProjectRequest) returns (DeleteVtsiProjectResponse);
 
-    // Deploy a VTSI project
+    // <p>Deploy a VTSI project</p>
     rpc DeployVtsiProject (DeployVtsiProjectRequest) returns (DeployVtsiProjectResponse);
 
-    // Undeploy a VTSI project
+    // <p>Undeploy a VTSI project</p>
     rpc UndeployVtsiProject (UndeployVtsiProjectRequest) returns (UndeployVtsiProjectResponse);
 
-    // Get a VTSI project with configs
+    // <p>Get a VTSI project with configs</p>
     rpc ListVtsiProjects (ListVtsiProjectsRequest) returns (ListVtsiProjectsResponse);
 
 }
@@ -53,7 +53,8 @@ service Projects {
 // The VTSI project with its configuration setting
 message VtsiProject{
 
-    // Required. The project name. Format: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
+    // Required. The project name.
+    // Format: <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     // Only when a new VtsiProject is created the name can be undefined/empty
     string name = 1;
 
@@ -93,8 +94,8 @@ message VtsiProject{
     // The port of the asterisk server
     int32 asterisk_port = 13;
 
-    // associated NLU agents
-    // Format: `projects/<Project ID>/agent`.
+    // Associated NLU agents.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     repeated string nlu_agent_names = 14;
 
     // The number of deployed callers in this project.
@@ -196,10 +197,10 @@ message AsteriskConfigs{
 // Request for creating a VTSI project
 message CreateVtsiProjectRequest{
 
-    // VTSI project
-    // Recommended is to leave "name" empty. The project name here is optional.
-    // If no name is given a new parent name is created. The parent has the format:
-    // <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>.
+    // <p>VTSI project</p>
+    // <p>Recommended is to leave &quot;name&quot; empty. The project name here is optional.</p>
+    // <p>If no name is given a new parent name is created. The parent has the format:</p>
+    // <pre><code>projects/&lt;project_uuid&gt;/project</code></pre>
     VtsiProject vtsi_project = 1;
 
     // error message if there are any.
@@ -240,8 +241,8 @@ message ListVtsiProjectsRequest {
     // If not specified, the default behavior is to have no sorting.
     optional VtsiProjectSorting vtsi_project_sorting = 3;
 
-    // Optional. Filter based on associated NLU agents
-    // Format: `projects/<Project ID>/agent`.
+    // Optional. Filter based on associated NLU agents.
+    // Format: <pre><code>projects/&lt;Project ID&gt;/agent</code></pre>
     repeated string nlu_agent_names = 4;
 }
 
@@ -249,7 +250,7 @@ message ListVtsiProjectsRequest {
 message ListVtsiProjectsResponse {
 
     // The list of VTSI projects returned in the response.
-    // Use the 'repeated' keyword to indicate that this field can contain multiple instances of VtsiProject.
+    // Use the &apos;repeated&apos; keyword to indicate that this field can contain multiple instances of VtsiProject.
     repeated VtsiProject vtsi_projects = 1;
 
     // Token to retrieve the next page of results.
@@ -301,10 +302,12 @@ enum VtsiProjectSortingMode {
 }
 
 // Structure of VTSI_PROJECT view
-// - CreateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW
-// - UpdateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW
-// - GetVTSI_PROJECT: VTSI_PROJECT_VIEW_FULL
-// - ListVTSI_PROJECTs: VTSI_PROJECT_VIEW_SHALLOW
+// <ul>
+//   <li>CreateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</li>
+//   <li>UpdateVTSI_PROJECT: VTSI_PROJECT_VIEW_SHALLOW</li>
+//   <li>GetVTSI_PROJECT: VTSI_PROJECT_VIEW_FULL</li>
+//   <li>ListVTSI_PROJECTs: VTSI_PROJECT_VIEW_SHALLOW</li>
+// </ul>
 enum VtsiProjectView {
 
     // Unspecified VTSI_PROJECT view: the view is defined by the call:
@@ -374,7 +377,7 @@ message DeployVtsiProjectResponse{
 
 }
 
-//  Request to undeploy a vtsi project
+// Request to undeploy a vtsi project
 message UndeployVtsiProjectRequest{
 
     // Project name of the VTSI project.


### PR DESCRIPTION
### This PR improves documentation generation and consistency across proto files by:

Adding dedicated documentation build targets to the **Makefile** to simplify and standardise the docs build process.

Updating all comments in `calls.proto` and `projects.proto` to use valid HTML formatting instead of Markdown, ensuring correct rendering in HTML-based proto documentation tools.